### PR TITLE
fix: correctly implement EIP 1155 tokenId padding

### DIFF
--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -1,5 +1,5 @@
 import { getAddress } from '@ethersproject/address'
-import { ethers, utils } from 'ethers'
+import { utils } from 'ethers'
 
 export function isAddressMatch(
   chainName: string,
@@ -13,12 +13,5 @@ export function isAddressMatch(
 }
 
 export function normalizeTokenID1155(tokenId: string) {
-  return utils
-    .hexlify(
-      utils.zeroPad(
-        utils.arrayify(ethers.BigNumber.from(tokenId).toHexString()),
-        64,
-      ),
-    )
-    .substr(4)
+  return utils.hexZeroPad(utils.arrayify(tokenId), 32).replace('0x', '')
 }

--- a/src/utils/addresses.ts
+++ b/src/utils/addresses.ts
@@ -1,5 +1,5 @@
 import { getAddress } from '@ethersproject/address'
-import { utils } from 'ethers'
+import { BigNumber, utils } from 'ethers'
 
 export function isAddressMatch(
   chainName: string,
@@ -13,5 +13,5 @@ export function isAddressMatch(
 }
 
 export function normalizeTokenID1155(tokenId: string) {
-  return utils.hexZeroPad(utils.arrayify(tokenId), 32).replace('0x', '')
+  return utils.hexZeroPad(utils.arrayify(BigNumber.from(tokenId)), 32).replace('0x', '')
 }


### PR DESCRIPTION
EIP 1155 requests that tokenIds be padded to "64 hex characters" but the current code pads the data to 64 bytes and then hexlifies it to 128 characters. the correct implementation is to just hexPad the data itself to the correct data length, which will naturally produce the correct hex character length.